### PR TITLE
Fix for PHP >=7.2 NULL is not countable

### DIFF
--- a/src/Xml.php
+++ b/src/Xml.php
@@ -53,6 +53,7 @@ class Xml
 		$this->root = $root ?? $this;
 		$this->parent = $parent;
 		$this->sub = false;
+		$this->children = [];
 	}
 
 	public static function createRoot(string $name = null): self


### PR DESCRIPTION
Starting from PHP 7.2, you get a warning on line 111, because `$this->children` is NULL, which is not countable:

https://github.com/lib16/xml-builder-php/blob/master/src/Xml.php#L111

This PR fixes it by initializing it as an array in the constructor.